### PR TITLE
fix: add Function type to component prop (#13)

### DIFF
--- a/src/components/MyToasts.vue
+++ b/src/components/MyToasts.vue
@@ -52,7 +52,7 @@ export default {
       default: 'bottom-right'
     },
     component: {
-      type: Object,
+      type: [Object, Function],
       required: true
     }
   },


### PR DESCRIPTION
Fixing invalid type warning when using with typescript class base component
by doing this, we fix #13 